### PR TITLE
Add research sources and requirements for knowledge graph enhancements

### DIFF
--- a/.lattice/requirements/cli/029-hotspot-analysis-command.yaml
+++ b/.lattice/requirements/cli/029-hotspot-analysis-command.yaml
@@ -1,0 +1,21 @@
+id: REQ-CLI-029
+type: requirement
+title: Hotspot Analysis Command
+body: 'A lattice hotspots command identifies structural risks in the knowledge graph: high-degree nodes (bottlenecks that are risky to change), fragile claims (theses supported by only one source), uncovered requirements (no implementations), and orphan nodes (no edges). Supports --type filter (fragile/bottleneck/uncovered/orphan) and --json for machine output.'
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:35:54.786996362+00:00
+created_by: agent:mcp-2026-04-06
+requested_by: Claude <noreply@anthropic.com>
+priority: P2
+category: CLI
+tags:
+- research-inspired
+- gh-issue-26
+edges:
+  derives_from:
+  - target: THX-VERSION-AWARE
+    version: 1.0.0
+  depends_on:
+  - target: REQ-CORE-002
+    version: 1.0.0

--- a/.lattice/requirements/core/016-confidence-tagged-edges-with-provenance.yaml
+++ b/.lattice/requirements/core/016-confidence-tagged-edges-with-provenance.yaml
@@ -1,0 +1,25 @@
+id: REQ-CORE-016
+type: requirement
+title: Confidence-Tagged Edges with Provenance
+body: 'Edges support an optional confidence field indicating provenance: asserted (human/agent explicitly created with evidence, weight 1.0), inferred (derived automatically from analysis, weight 0.8), or ambiguous (suspected but unconfirmed, weight 0.5). Drift detection prioritizes ambiguous edges for review. Export views can filter or highlight by confidence level. Default confidence for human-created edges is asserted; for agent-created edges is inferred.'
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:35:49.461562441+00:00
+created_by: agent:mcp-2026-04-06
+requested_by: Claude <noreply@anthropic.com>
+priority: P1
+category: CORE
+tags:
+- research-inspired
+- gh-issue-24
+edges:
+  derives_from:
+  - target: THX-BIDIRECTIONAL-FLOW
+    version: 1.0.0
+  - target: THX-AGENT-NATIVE-TOOLS
+    version: 1.0.0
+  depends_on:
+  - target: REQ-CORE-002
+    version: 1.0.0
+  - target: REQ-CORE-005
+    version: 1.0.0

--- a/.lattice/requirements/core/017-transitive-impact-analysis--blast-radius.yaml
+++ b/.lattice/requirements/core/017-transitive-impact-analysis--blast-radius.yaml
@@ -1,0 +1,25 @@
+id: REQ-CORE-017
+type: requirement
+title: Transitive Impact Analysis (Blast Radius)
+body: A lattice impact command performs transitive graph traversal from a given node to show all directly and transitively affected nodes. Supports --depth to limit traversal, --direction (upstream/downstream/both), and --json for machine output. Extends drift detection from direct-edge staleness to full change propagation analysis.
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:35:52.394406136+00:00
+created_by: agent:mcp-2026-04-06
+requested_by: Claude <noreply@anthropic.com>
+priority: P1
+category: CORE
+tags:
+- research-inspired
+- gh-issue-25
+edges:
+  derives_from:
+  - target: THX-VERSION-AWARE
+    version: 1.0.0
+  - target: THX-AGENT-NATIVE-TOOLS
+    version: 1.0.0
+  depends_on:
+  - target: REQ-CORE-003
+    version: 1.0.0
+  - target: REQ-CORE-005
+    version: 1.0.0

--- a/.lattice/sources/blast-radius.yaml
+++ b/.lattice/sources/blast-radius.yaml
@@ -1,0 +1,18 @@
+id: SRC-BLAST-RADIUS
+type: source
+title: Blast Radius Analysis in Code Knowledge Graphs
+body: 'Code-review-graph and CodeGraph both implement transitive impact analysis (blast radius) over code dependency graphs. When files change, they trace callers, dependents, and tests through the graph to compute the minimal affected set. The technique — standard graph traversal from changed nodes through dependency edges — is directly applicable to any directed knowledge graph including requirement traceability graphs. code-review-graph: MIT licensed. CodeGraph: MIT licensed.'
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:34:20.051099384+00:00
+created_by: agent:claude-opus
+requested_by: Claude <noreply@anthropic.com>
+meta:
+  url: https://github.com/tirth8205/code-review-graph
+  reliability: industry
+  retrieved_at: 2026-04-06
+edges:
+  supported_by:
+  - target: THX-VERSION-AWARE
+    version: 1.0.0
+    rationale: Demonstrates transitive impact analysis as extension of version-aware drift detection

--- a/.lattice/sources/graph-centrality.yaml
+++ b/.lattice/sources/graph-centrality.yaml
@@ -1,0 +1,18 @@
+id: SRC-GRAPH-CENTRALITY
+type: source
+title: Node Centrality Analysis for Knowledge Graph Health
+body: 'Degree and betweenness centrality are foundational graph metrics for identifying bottleneck nodes, fragile structures, and structural risks. Applied to knowledge graphs: high-degree nodes are change-risk hotspots, single-source theses are fragile claims, and orphan nodes indicate incomplete coverage. Well-established in graph theory literature (Freeman 1977, Brandes 2001). Graphify applies god-node detection to code graphs as a practical example.'
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:34:23.221355976+00:00
+created_by: agent:claude-opus
+requested_by: Claude <noreply@anthropic.com>
+meta:
+  url: https://en.wikipedia.org/wiki/Centrality
+  reliability: peer_reviewed
+  retrieved_at: 2026-04-06
+edges:
+  supported_by:
+  - target: THX-VERSION-AWARE
+    version: 1.0.0
+    rationale: Centrality metrics identify structural risks that complement version-aware drift detection

--- a/.lattice/sources/graphify.yaml
+++ b/.lattice/sources/graphify.yaml
@@ -1,0 +1,18 @@
+id: SRC-GRAPHIFY
+type: source
+title: 'Graphify: Confidence-Tagged Knowledge Graphs from Code'
+body: 'Claude Code skill that builds knowledge graphs from codebases with confidence-tagged edges (EXTRACTED/INFERRED/AMBIGUOUS). Uses AST parsing, Leiden community clustering, and content-addressed SHA256 caching. Key insight: tagging edge provenance enables prioritized review and surfaces ambiguous relationships as suggested questions. MIT licensed.'
+status: active
+version: 1.0.0
+created_at: 2026-04-06T02:34:16.502772409+00:00
+created_by: agent:claude-opus
+requested_by: Claude <noreply@anthropic.com>
+meta:
+  url: https://github.com/safishamsi/graphify
+  reliability: industry
+  retrieved_at: 2026-04-06
+edges:
+  supported_by:
+  - target: THX-AGENT-NATIVE-TOOLS
+    version: 1.0.0
+    rationale: Demonstrates that confidence-tagged edges improve agent knowledge graph interactions


### PR DESCRIPTION
Research from r/ClaudeCode community projects (Graphify, code-review-graph,
CodeGraph, Understand-Anything) identified three high-value ideas for Lattice:

Sources:
- SRC-GRAPHIFY: Confidence-tagged edges from Graphify (MIT)
- SRC-BLAST-RADIUS: Transitive impact analysis from code-review-graph/CodeGraph (MIT)
- SRC-GRAPH-CENTRALITY: Node centrality analysis (academic literature)

Requirements:
- REQ-CORE-016: Confidence-tagged edges (asserted/inferred/ambiguous)
- REQ-CORE-017: Transitive impact analysis (blast radius) command
- REQ-CLI-029: Hotspot analysis command (god nodes, fragile claims)

GitHub issues: #24, #25, #26

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01Jp9Li2iUeC8HgrxA82TudV