### PR TITLE
Make update notice more visible with color and version diff

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,23 @@
 #!/bin/sh
 # Lattice installer
 # Usage: curl -fsSL https://forkzero.ai/lattice/install.sh | sh
+#
+# Environment variables:
+#   INSTALL_DIR  Override install location (default: ~/.local/bin)
+#   VERSION      Install a specific version (default: latest)
 
 set -e
 
 REPO="forkzero/lattice"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Default to ~/.local/bin (user-writable, no sudo needed)
+if [ -z "$INSTALL_DIR" ]; then
+    if [ -w "/usr/local/bin" ]; then
+        INSTALL_DIR="/usr/local/bin"
+    else
+        INSTALL_DIR="${HOME}/.local/bin"
+    fi
+fi
 
 # Detect OS
 OS="$(uname -s)"
@@ -65,6 +77,9 @@ fi
 echo "Extracting..."
 tar -xzf "$ARCHIVE"
 
+# Ensure install directory exists
+mkdir -p "$INSTALL_DIR"
+
 # Install
 BINARY_DIR="lattice-${VERSION}-${TARGET}"
 if [ -w "$INSTALL_DIR" ]; then
@@ -74,6 +89,23 @@ else
     sudo mv "${BINARY_DIR}/lattice" "$INSTALL_DIR/"
 fi
 
+# Check if install dir is in PATH
+case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+        echo ""
+        echo "Add ${INSTALL_DIR} to your PATH:"
+        SHELL_NAME="$(basename "$SHELL")"
+        case "$SHELL_NAME" in
+            zsh)  echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc" ;;
+            bash) echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
+            fish) echo "  fish_add_path ${INSTALL_DIR}" ;;
+            *)    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+        esac
+        echo ""
+        ;;
+esac
+
 # Verify
 if command -v lattice > /dev/null 2>&1; then
     echo ""
@@ -82,8 +114,9 @@ if command -v lattice > /dev/null 2>&1; then
     echo "Get started:"
     echo "  lattice init          # Initialize a lattice"
     echo "  lattice --help        # Show all commands"
+    echo "  lattice help concepts # Learn the domain model"
 else
     echo ""
     echo "Installed to ${INSTALL_DIR}/lattice"
-    echo "Add ${INSTALL_DIR} to your PATH if not already present."
+    echo "Make sure ${INSTALL_DIR} is in your PATH."
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -4445,7 +4445,9 @@ fn run_command(command: Commands) {
                             (
                                 format!("Permission denied — cannot write to {}", exe),
                                 if cfg!(unix) {
-                                    Some("Run with sudo: sudo lattice update")
+                                    Some(
+                                        "Reinstall to ~/.local/bin for sudo-free updates:\n  INSTALL_DIR=~/.local/bin curl -fsSL https://forkzero.ai/lattice/install.sh | sh\nOr run: sudo lattice update",
+                                    )
                                 } else {
                                     None
                                 },

--- a/src/update.rs
+++ b/src/update.rs
@@ -374,15 +374,16 @@ fn write_check_state(path: &std::path::Path, state: &UpdateCheckState) {
         .and_then(|json| std::fs::write(path, json).ok());
 }
 
-fn print_update_notice(latest: &Version) {
+fn print_update_notice(current: &Version, latest: &Version) {
+    eprintln!();
     eprintln!(
-        "{}",
-        format!(
-            "A new version of lattice is available (v{}). Run 'lattice update' to install.",
-            latest
-        )
-        .dimmed()
+        "  {} {} → {}",
+        "Update available:".yellow().bold(),
+        format!("v{}", current).dimmed(),
+        format!("v{}", latest).green().bold()
     );
+    eprintln!("  Run {} to install", "lattice update".cyan());
+    eprintln!();
 }
 
 /// Print a one-line update notice to stderr if a newer version is available.
@@ -420,7 +421,7 @@ pub fn maybe_notify_update(command_name: Option<&str>) {
             if let Ok(latest) = Version::parse(&state.latest_version)
                 && latest > current
             {
-                print_update_notice(&latest);
+                print_update_notice(&current, &latest);
             }
             return;
         }
@@ -449,7 +450,7 @@ pub fn maybe_notify_update(command_name: Option<&str>) {
                 },
             );
             if latest > current {
-                print_update_notice(&latest);
+                print_update_notice(&current, &latest);
             }
         }
         Err(_) => {


### PR DESCRIPTION
## Summary

Two improvements to the update experience:

### 1. More visible update notice
The notification was a dimmed one-liner easily missed. Now colored with version diff:
```
  Update available: v0.2.4 → v0.2.5
  Run lattice update to install
```

### 2. Install to ~/.local/bin by default (sudo-free updates)
The install script now defaults to `~/.local/bin` when `/usr/local/bin` isn't writable. This means:
- `lattice update` works without sudo
- Auto-update becomes possible (future)
- Fresh installs don't need elevated permissions

When `~/.local/bin` isn't in PATH, prints shell-specific instructions (zsh/bash/fish).

The `lattice update` permission error now suggests reinstalling to `~/.local/bin` instead of just recommending sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)