### PR TITLE
Fix edit --status contested and add edit --confidence (#37, #38)

### DIFF
--- a/skills/lattice/SKILL.md
+++ b/skills/lattice/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: lattice
+# Auto-updated by lattice when version changes. Remove this version line to disable auto-updates.
+version: LATTICE_VERSION
 description: "Lattice knowledge graph integration. Use when working in a project with a .lattice/ directory — for requirements, theses, sources, implementations, messages, drift detection, or lattice CLI commands."
 allowed-tools: Bash(lattice *), Bash(./target/release/lattice *), Bash(./target/debug/lattice *), Bash(gh issue *), Read, Grep, Glob
 ---
@@ -61,6 +63,15 @@ gh issue create --repo forkzero/lattice \
 ### If Gaps Are Found
 - `lattice refine REQ-XXX --gap-type missing_requirement --title "..." --description "..."` to create sub-requirements
 - `lattice add edge --from IMP-XXX --type reveals_gap_in --to REQ-XXX --rationale "..."` to record feedback
+
+### Challenging Theses
+When evidence contradicts a strategic claim, agents SHOULD challenge it:
+1. `lattice add thesis --id THX-COUNTER-... --title "..." --body "..." --category technical` — create a counter-thesis
+2. `lattice add edge --from THX-COUNTER-... --type rebuts --to THX-ORIGINAL` — link the challenge
+3. `lattice edit THX-ORIGINAL --status contested --confidence <lower value>` — mark as under debate
+4. `lattice assess` — check change pressure on downstream requirements
+
+Run `lattice help workflows` for the full `adversarial_debate` and `resolve_code_impact` sequences.
 
 ## JSON Output
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,13 +168,17 @@ enum Commands {
         #[arg(long)]
         body: Option<String>,
 
-        /// New status (draft, active, deprecated, superseded)
+        /// New status (draft, active, contested, deprecated, superseded)
         #[arg(long)]
         status: Option<String>,
 
         /// New priority (P0, P1, P2) — requirements only
         #[arg(long)]
         priority: Option<String>,
+
+        /// New confidence (0.0-1.0) — theses only
+        #[arg(long)]
+        confidence: Option<f64>,
 
         /// Comma-separated tags (replaces existing)
         #[arg(long)]
@@ -832,23 +836,10 @@ fn parse_priority(s: &str) -> Priority {
 }
 
 fn parse_status(s: &str) -> Status {
-    match s.to_lowercase().as_str() {
-        "draft" => Status::Draft,
-        "active" => Status::Active,
-        "deprecated" => Status::Deprecated,
-        "superseded" => Status::Superseded,
-        _ => {
-            eprintln!(
-                "{}",
-                format!(
-                    "Invalid status: {}. Must be draft, active, deprecated, or superseded",
-                    s
-                )
-                .red()
-            );
-            process::exit(1);
-        }
-    }
+    s.parse::<Status>().unwrap_or_else(|e| {
+        eprintln!("{}", e.red());
+        process::exit(1);
+    })
 }
 
 fn parse_reliability(s: &str) -> lattice::types::Reliability {
@@ -969,15 +960,58 @@ fn install_agent_definitions(root: &std::path::Path) -> Result<Vec<std::path::Pa
     Ok(created)
 }
 
+fn skill_content() -> String {
+    include_str!("../skills/lattice/SKILL.md").replace("LATTICE_VERSION", env!("CARGO_PKG_VERSION"))
+}
+
 fn install_skill_definitions(root: &std::path::Path) -> Result<Vec<std::path::PathBuf>, String> {
     let skill_dir = root.join(".claude").join("skills").join("lattice");
     std::fs::create_dir_all(&skill_dir).map_err(|e| e.to_string())?;
 
     let skill_path = skill_dir.join("SKILL.md");
-    std::fs::write(&skill_path, include_str!("../skills/lattice/SKILL.md"))
-        .map_err(|e| e.to_string())?;
+    std::fs::write(&skill_path, skill_content()).map_err(|e| e.to_string())?;
 
     Ok(vec![skill_path])
+}
+
+/// Auto-update the installed SKILL.md if it has a version line older than the binary.
+/// Skips if no skill is installed or if the version line was removed (user opted out).
+fn maybe_update_skill(root: &std::path::Path) {
+    let skill_path = root
+        .join(".claude")
+        .join("skills")
+        .join("lattice")
+        .join("SKILL.md");
+    if !skill_path.exists() {
+        return;
+    }
+
+    let content = match std::fs::read_to_string(&skill_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Look for version line in frontmatter
+    let version_line = content.lines().find(|l| l.starts_with("version:"));
+    let installed_version = match version_line {
+        Some(line) => line.trim_start_matches("version:").trim().to_string(),
+        None => return, // No version line = user opted out of auto-updates
+    };
+
+    let current_version = env!("CARGO_PKG_VERSION");
+    if installed_version == current_version {
+        return; // Already current
+    }
+
+    // Regenerate
+    if std::fs::write(&skill_path, skill_content()).is_ok() {
+        eprintln!(
+            "  {} SKILL.md {} → {}",
+            "Updated:".green().bold(),
+            installed_version.dimmed(),
+            current_version.green()
+        );
+    }
 }
 
 fn detect_claude_code(root: &std::path::Path) -> bool {
@@ -1932,6 +1966,11 @@ fn main() {
     // Apply any staged auto-update before anything else
     lattice::update::apply_staged_update();
 
+    // Auto-update skill if installed and outdated
+    if let Some(root) = find_lattice_root(&std::env::current_dir().unwrap_or_default()) {
+        maybe_update_skill(&root);
+    }
+
     // Intercept top-level --help/-h and --version/-V before clap parses,
     // so subcommand --help still uses clap's built-in per-command help,
     // and --version can show the passive update notification.
@@ -2575,6 +2614,7 @@ fn run_command(command: Commands) {
             body,
             status,
             priority,
+            confidence,
             tags,
             category,
             files,
@@ -2593,6 +2633,7 @@ fn run_command(command: Commands) {
                 body,
                 status,
                 priority,
+                confidence,
                 tags,
                 category,
                 files,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,8 +3,8 @@
 //! Linked requirements: REQ-CORE-004, REQ-CLI-002, REQ-AGENT-002
 
 use crate::types::{
-    EdgeReference, Edges, LatticeNode, MessageMeta, NodeMeta, NodeType, Priority, Reliability,
-    Resolution, ResolutionInfo, SourceMeta, Status, ThesisCategory, ThesisMeta,
+    ConfidenceEntry, EdgeReference, Edges, LatticeNode, MessageMeta, NodeMeta, NodeType, Priority,
+    Reliability, Resolution, ResolutionInfo, SourceMeta, Status, ThesisCategory, ThesisMeta,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -773,6 +773,7 @@ pub struct EditNodeOptions {
     pub body: Option<String>,
     pub status: Option<Status>,
     pub priority: Option<Priority>,
+    pub confidence: Option<f64>,
     pub tags: Option<Vec<String>>,
     pub category: Option<String>,
     pub files: Option<Vec<String>>,
@@ -824,6 +825,27 @@ pub fn edit_node(root: &Path, options: EditNodeOptions) -> Result<PathBuf, Stora
         if node.priority.as_ref() != Some(&new_priority) {
             node.priority = Some(new_priority);
             changed = true;
+        }
+    }
+    if let Some(new_confidence) = options.confidence {
+        if node.node_type != NodeType::Thesis {
+            return Err(StorageError::InvalidField(
+                "Confidence can only be set on thesis nodes".to_string(),
+            ));
+        }
+        if let Some(NodeMeta::Thesis(ref mut meta)) = node.meta {
+            let old_confidence = meta.confidence_value();
+            if (new_confidence - old_confidence).abs() > f64::EPSILON {
+                // Record history entry before updating
+                meta.confidence_history.push(ConfidenceEntry {
+                    value: new_confidence,
+                    reason: None,
+                    updated_by: get_git_user().unwrap_or_else(|| "unknown".to_string()),
+                    updated_at: chrono::Utc::now().to_rfc3339(),
+                });
+                meta.confidence = Some(new_confidence);
+                changed = true;
+            }
         }
     }
     if let Some(tags) = options.tags
@@ -2307,6 +2329,7 @@ mod tests {
                 body: Some("New body".to_string()),
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -2352,6 +2375,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: Some(vec!["alpha".to_string(), "beta".to_string()]),
                 category: Some("NEW".to_string()),
                 files: None,
@@ -2400,6 +2424,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -2443,6 +2468,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: Some(crate::types::Priority::P0),
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -2485,6 +2511,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: Some(crate::types::Priority::P0),
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -2530,6 +2557,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: Some(vec!["src/new.rs".to_string(), "src/lib.rs".to_string()]),
@@ -2577,6 +2605,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -2623,6 +2652,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: Some(vec!["src/foo.rs".to_string()]),
@@ -3084,6 +3114,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -3106,6 +3137,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,
@@ -3169,6 +3201,7 @@ mod tests {
                 body: None,
                 status: None,
                 priority: None,
+                confidence: None,
                 tags: None,
                 category: None,
                 files: None,


### PR DESCRIPTION
## Summary

Two cli-gap fixes that unblock the adversarial debate workflow.

### #37: `lattice edit --status contested` now works
`parse_status()` was a hardcoded match that predated the `Contested` variant. Now delegates to `Status::from_str` which already includes it. The documented `adversarial_debate` workflow step 4 (`lattice edit <thesis-id> --status contested`) works as expected.

### #38: `lattice edit --confidence <float>` added
Thesis confidence can now be revised after creation. Records a `ConfidenceEntry` in `confidence_history` with user and timestamp, feeding into `lattice assess`'s `theses_with_confidence_changes` metric. Rejects non-thesis nodes with a clear error.

### Tested
```bash
$ lattice edit THX-AGENT-PRODUCT-OWNER --status contested
Updated THX-AGENT-PRODUCT-OWNER (version: 1.0.1)

$ lattice edit THX-AGENT-PRODUCT-OWNER --confidence 0.7
Updated THX-AGENT-PRODUCT-OWNER (version: 1.0.2)

$ lattice assess --format json | jq '.theses_with_confidence_changes'
1
```

Fixes #37, Fixes #38